### PR TITLE
feat: Add continuous delivery with docker.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,8 @@ on:
   pull_request:
    branches: [ "master", "develop", "bugfix/*", "feature/*" ]
 
-  release:
-    types: 
-      - published
 jobs:
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -36,51 +34,3 @@ jobs:
       run: mv Adempiere/packages/*/lib/*.jar dependences/
     - name: Build with Gradle
       run: gradle build
-  publish:
-    needs: build
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: create dependences folder
-      run: mkdir dependences
-    - name: get adempiere source
-      run: wget https://github.com/erpcya/adempiere/releases/download/3.9.3-rs-4.0/Adempiere_393LTS.tar.gz -c -O Adempiere.tar.gz
-    - name: uncompress file
-      run: tar -xzf Adempiere.tar.gz
-    - name: move dependences
-      run: mv Adempiere/lib/*.jar dependences/
-    - name: move packages
-      run: mv Adempiere/packages/*/lib/*.jar dependences/
-    - name: Build with Gradle
-      run: gradle createRelease
-    - name: Upload zip
-      uses: skx/github-action-publish-binaries@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.TOKEN_ACCESS }}
-      with:
-        args: 'build/release/*.zip'
-    - name: Upload zip.MD5
-      uses: skx/github-action-publish-binaries@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.TOKEN_ACCESS }}
-      with:
-        args: 'build/release/*.zip.MD5'
-    - name: Upload tar
-      uses: skx/github-action-publish-binaries@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.TOKEN_ACCESS }}
-      with:
-        args: 'build/release/*.tar'
-    - name: Upload tar.MD5
-      uses: skx/github-action-publish-binaries@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.TOKEN_ACCESS }}
-      with:
-        args: 'build/release/*.tar.MD5'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,219 @@
+# This workflow will build a Java project with Gradle
+# This file was contributed by EdwinBetanc0urt@outlook.com from ERP Consultores y Asociados, C.A
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Publish Project
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+
+  # Build dist application ADempiere-gRPC-Server
+  build-app:
+    name: Build dist ADempiere-gRPC-Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt-hotspot'
+          java-version: 8
+
+      - name: get adempiere source
+        run: |
+          download_repo="https://github.com/erpcya/adempiere/releases/download/3.9.3-rs-4.0/Adempiere_393LTS.tar.gz"
+          wget $download_repo -c -O Adempiere.tar.gz
+
+      - name: uncompress file
+        run: tar -xzf Adempiere.tar.gz
+
+      - name: create dependences folder
+        run: mkdir dependences
+      - name: move dependences
+        run: mv Adempiere/lib/*.jar dependences/
+      - name: move packages
+        run: mv Adempiere/packages/*/lib/*.jar dependences/
+
+      - name: Build with Gradle
+        run: gradle createRelease
+
+      - name: Upload dist app zip artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: adempiere-gRPC-Server.zip
+          path: build/release/adempiere-gRPC-Server.zip
+
+      - name: Upload dist app zip.MD5 artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: adempiere-gRPC-Server.zip.MD5
+          path: build/release/adempiere-gRPC-Server.zip.MD5
+
+      - name: Upload dist app tar artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: adempiere-gRPC-Server.tar
+          path: build/release/adempiere-gRPC-Server.tar
+
+      - name: Upload dist app tar.MD5 artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: adempiere-gRPC-Server.tar.MD5
+          path: build/release/adempiere-gRPC-Server.tar.MD5
+
+
+  publish-binaries:
+    name: Upload Binaries ADempiere-gRPC-Server
+    needs: build-app
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Upload zip
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: adempiere-gRPC-Server.zip/adempiere-gRPC-Server.zip
+
+      - name: Upload zip.MD5
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: adempiere-gRPC-Server.zip.MD5/adempiere-gRPC-Server.zip.MD5
+
+      - name: Upload tar
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: adempiere-gRPC-Server.tar/adempiere-gRPC-Server.tar
+
+      - name: Upload tar.MD5
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: adempiere-gRPC-Server.tar.MD5/adempiere-gRPC-Server.tar.MD5
+
+
+  # Publish docker image in Github Container Registry to application
+  push-imame-ghcr:
+    name: Push Docker image to GitHub Container
+    needs: build-app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Download build dist app
+        uses: actions/download-artifact@v2
+        with:
+          name: adempiere-gRPC-Server.zip
+          path: dist
+
+      - name: Unzip dist file
+        run: |
+          cd dist
+          unzip -o adempiere-gRPC-Server.zip
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Lower Case to owner and repository
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+          echo "REPO_LC=${NAME,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+          NAME: '${{ github.event.repository.name }}'
+
+      - name: Push image in GH Container
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build-docker/Dockerfile.prod
+          push: true
+          # load: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/${{ env.REPO_LC }}:latest
+            ghcr.io/${{ env.OWNER_LC }}/${{ env.REPO_LC }}:${{ github.sha }}
+            ghcr.io/${{ env.OWNER_LC }}/${{ env.REPO_LC }}:${{ github.event.release.tag_name }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+
+  # Publish docker image in Docker Hub registry to application
+  push-imame-dhr:
+    name: Push Docker image to Docker Hub
+    needs:
+      - build-app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Download build dist app
+        uses: actions/download-artifact@v2
+        with:
+          name: adempiere-gRPC-Server.zip
+          path: dist
+
+      - name: Unzip dist file
+        run: |
+          cd dist
+          unzip -o adempiere-gRPC-Server.zip
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          # CONFIGURE DOCKER SECRETS INTO REPOSITORY
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Lower Case to owner and repository
+        run: |
+          ORG=$OWNER
+          if [ -n "${{ secrets.DOCKERHUB_ORG }}" ]; then
+            echo "Set secret DOCKERHUB_ORG as namespace"
+            ORG=${{ secrets.DOCKERHUB_ORG }}
+          else
+            echo "Set OWNER ($OWNER) as namespace "
+          fi
+          echo "ORG_LC=${ORG,,}" >> ${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+          echo "REPO_LC=${NAME,,}" >> ${GITHUB_ENV}
+        env:
+          # to docker image namespace
+          OWNER: '${{ github.repository_owner }}'
+          NAME: '${{ github.event.repository.name }}'
+
+      - name: Push image in Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build-docker/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.ORG_LC }}/${{ env.REPO_LC }}:latest
+            ${{ env.ORG_LC }}/${{ env.REPO_LC }}:${{ github.sha }}
+            ${{ env.ORG_LC }}/${{ env.REPO_LC }}:${{ github.event.release.tag_name }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/build-docker/Dockerfile.dist
+++ b/build-docker/Dockerfile.dist
@@ -1,0 +1,55 @@
+FROM adoptopenjdk/openjdk8:jre8u275-b01-alpine
+
+LABEL	maintainer="ysenih@erpya.com; EdwinBetanc0urt@outlook.com" \
+	description="ADempiere gRPC All In One Server used as ADempiere backend"
+
+# Add operative system dependencies
+RUN	echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main" > /etc/apk/repositories && \
+	echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories && \
+	rm -rf /var/cache/apk/* && \
+	apk update && \
+	apk add --virtual .build-deps \
+	 	ca-certificates \
+	 	curl && \
+	apk add \
+		bash \
+	 	fontconfig \
+		ttf-dejavu
+
+ARG URL_REPO="https://github.com/adempiere/adempiere-gRPC-Server"
+ARG BINARY_NAME="adempiere-gRPC-Server.zip"
+ARG BASE_VERSION="rt-21.9"
+
+# Init ENV with default values
+ENV	BASE_VERSION=$BASE_VERSION \
+	SERVER_PORT="50059" \
+	SERVICES_ENABLED="access; business; core; dashboarding; dictionary; enrollment; log; ui; workflow; store; pos;" \
+	SERVER_LOG_LEVEL="WARNING" \
+	DB_HOST="localhost" \
+	DB_PORT="5432" \
+	DB_NAME="adempiere" \
+	DB_USER="adempiere" \
+	DB_PASSWORD="adempiere" \
+	DB_TYPE="PostgreSQL"
+
+# Download and uncompress project
+RUN	mkdir -p /opt/Apps && \
+	cd /opt/Apps && \
+	curl --output "$BINARY_NAME" \
+		-L "$URL_REPO/releases/download/$BASE_VERSION/$BINARY_NAME" && \
+	unzip -o $BINARY_NAME && \
+	mv adempiere-gRPC-Server ADempiere-gRPC-Server && \
+	# delete unused files
+	rm $BINARY_NAME && \
+	apk del .build-deps && \
+	rm -rf /var/cache/apk/* \
+		/var/lib/apt/list/* \
+		/tmp/*
+
+# Add connection template and start script files
+COPY "all_in_one_connection.yaml" "start.sh" "/opt/Apps/ADempiere-gRPC-Server/bin/"
+
+WORKDIR /opt/Apps/ADempiere-gRPC-Server/bin/
+
+# Start app
+CMD	'sh' 'start.sh'

--- a/build-docker/Dockerfile.prod
+++ b/build-docker/Dockerfile.prod
@@ -1,0 +1,52 @@
+FROM adoptopenjdk/openjdk8:jre8u275-b01-alpine
+
+
+LABEL	maintainer="ysenih@erpya.com; EdwinBetanc0urt@outlook.com" \
+	description="ADempiere gRPC All In One Server used as ADempiere backend"
+
+
+# Add operative system dependencies
+RUN	echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main" > /etc/apk/repositories && \
+	echo "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories && \
+	rm -rf /var/cache/apk/* && \
+	apk update && \
+	apk add \
+		bash \
+	 	fontconfig \
+		ttf-dejavu
+
+
+# Init ENV with default values
+ENV \
+	SERVER_PORT="50059" \
+	SERVICES_ENABLED="access; business; core; dashboarding; dictionary; enrollment; log; ui; workflow; store; pos;" \
+	SERVER_LOG_LEVEL="WARNING" \
+	DB_HOST="localhost" \
+	DB_PORT="5432" \
+	DB_NAME="adempiere" \
+	DB_USER="adempiere" \
+	DB_PASSWORD="adempiere" \
+	DB_TYPE="PostgreSQL"
+
+
+EXPOSE ${SERVER_PORT}
+
+
+# Download and uncompress project
+RUN	mkdir -p /opt/Apps/ADempiere-gRPC-Server && \
+	# delete unused files
+	rm -rf /var/cache/apk/* \
+		/var/lib/apt/list/* \
+		/tmp/*
+
+
+# Add connection template and start script files
+COPY "build-docker/all_in_one_connection.yaml" "build-docker/start.sh" "/opt/Apps/ADempiere-gRPC-Server/bin/"
+COPY dist/adempiere-gRPC-Server/ /opt/Apps/ADempiere-gRPC-Server/
+
+
+WORKDIR /opt/Apps/ADempiere-gRPC-Server/bin/
+
+
+# Start app
+CMD	'sh' 'start.sh'

--- a/build-docker/all_in_one_connection.yaml
+++ b/build-docker/all_in_one_connection.yaml
@@ -1,0 +1,12 @@
+server:
+    port: 50059
+    services:
+        - services_enabled
+    log_level: WARNING
+database:
+    host: localhost
+    port: 5432
+    name: adempieredb
+    user: adempiereuser
+    password: adempierepass
+    type: PostgreSQL

--- a/build-docker/start.sh
+++ b/build-docker/start.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# @autor Edwin Betancourt <EdwinBetanc0urt@outlook.com>
+
+# Set server values
+sed -i "s|50059|$SERVER_PORT|g" all_in_one_connection.yaml
+sed -i "s|WARNING|$SERVER_LOG_LEVEL|g" all_in_one_connection.yaml
+
+
+# create array to iterate
+SERVICES_LIST=$(echo $SERVICES_ENABLED | tr "; " "\n")
+
+SERVICES_LIST_TO_SET=""
+for SERVICE_ITEM in $SERVICES_LIST
+do
+    # Service to lower case
+    SERVICE_LOWER_CASE=$(echo $SERVICE_ITEM | tr '[:upper:]' '[:lower:]')
+
+    NEW_LINE="\n"
+    PREFIX="        - "
+    if [ -z "$SERVICES_LIST_TO_SET" ]
+    then
+        NEW_LINE=""
+        PREFIX="- "
+    fi
+
+    # Add to the list of services
+    SERVICES_LIST_TO_SET="${SERVICES_LIST_TO_SET}${NEW_LINE}${PREFIX}${SERVICE_LOWER_CASE}"
+done
+
+sed -i "s|- services_enabled|$SERVICES_LIST_TO_SET|g" all_in_one_connection.yaml
+
+
+# Set data base conection values
+sed -i "s|localhost|$DB_HOST|g" all_in_one_connection.yaml
+sed -i "s|5432|$DB_PORT|g" all_in_one_connection.yaml
+sed -i "s|adempieredb|$DB_NAME|g" all_in_one_connection.yaml
+sed -i "s|adempiereuser|$DB_USER|g" all_in_one_connection.yaml
+sed -i "s|adempierepass|$DB_PASSWORD|g" all_in_one_connection.yaml
+sed -i "s|PostgreSQL|$DB_TYPE|g" all_in_one_connection.yaml
+
+
+# Run app
+./adempiere-all-in-one-server ./all_in_one_connection.yaml


### PR DESCRIPTION
https://github.com/EdwinBetanc0urt/adempiere-gRPC-Server/actions/runs/1140803152

![gh-actions-grpc](https://user-images.githubusercontent.com/20288327/129801215-4c3f7052-7611-4695-96b1-d5058016a9db.png)

https://github.com/EdwinBetanc0urt/adempiere-gRPC-Server/pkgs/container/adempiere-grpc-server
![ghcr](https://user-images.githubusercontent.com/20288327/129801277-76197b50-c5d6-4e38-83cb-492bf50530b6.png)

https://hub.docker.com/r/edwinbetanc0urt/adempiere-grpc-server

![grpc-docker-hub](https://user-images.githubusercontent.com/20288327/129801283-e2bbc80f-d451-42a8-a1ef-5a831bf9f314.png)


#### Note:
Deprecated repository https://github.com/adempiere/adempiere-grpc-all-in-one-docker

Adding secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`, optionally add the secret `DOCKERHUB_ORG` for the namespace name in docker-hub image, otherwise it will take the value of the `DOCKERHUB_USERNAME` secret for the namespace.