### PR TITLE
fix: Get and unlock private access.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -401,7 +401,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			if (requestGeneric instanceof UnlockPrivateAccessRequest) {
 				request = (UnlockPrivateAccessRequest) requestGeneric;
 			} else if (requestGeneric instanceof LockPrivateAccessRequest) {
-				request = (LockPrivateAccessRequest) requestGeneric
+				request = (LockPrivateAccessRequest) requestGeneric;
 			}
 
 			if(request == null) {

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -368,19 +368,42 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 	}
 	
 	@Override
+	/**
+	 * TODO: Replace LockPrivateAccessRequest with GetPrivateAccessRequest
+	 * @param request
+	 * @param responseObserver
+	 */
 	public void lockPrivateAccess(LockPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
-		setPrivateAccess((GetPrivateAccessRequest) request, responseObserver, true);
+		setPrivateAccess(request, responseObserver, true);
 	}
 	
 	@Override
+	/**
+	 * TODO: Replace UnlockPrivateAccessRequest with GetPrivateAccessRequest
+	 * @param request
+	 * @param responseObserver
+	 */
 	public void unlockPrivateAccess(UnlockPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
-		setPrivateAccess((GetPrivateAccessRequest) request, responseObserver, false);
+		setPrivateAccess(request, responseObserver, false);
 	}
 
-	public void setPrivateAccess(GetPrivateAccessRequest request,
+	/**
+	 * TODO: Use GetPrivateAccessRequest as request
+	 * @param request
+	 * @param responseObserver
+	 * @param isPrivateAccess
+	 */
+	public void setPrivateAccess(Object requestGeneric,
 		StreamObserver<PrivateAccess> responseObserver,
 		boolean isPrivateAccess) {
 		try {
+			Object request = null;
+			if (requestGeneric instanceof UnlockPrivateAccessRequest) {
+				request = (UnlockPrivateAccessRequest) requestGeneric;
+			} else if (requestGeneric instanceof LockPrivateAccessRequest) {
+				request = (LockPrivateAccessRequest) requestGeneric
+			}
+
 			if(request == null) {
 				throw new AdempiereException("Object Request Null");
 			}

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -381,12 +381,13 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		StreamObserver<PrivateAccess> responseObserver,
 		boolean isPrivateAccess) {
 		try {
-			if (request == null) {
+			if(request == null) {
 				throw new AdempiereException("Object Request Null");
 			}
 
 			int recordId = request.getId();
-			if (recordId <= 0 && Util.isEmpty(request.getUuid())) {
+			if (recordId <= 0
+					&& Util.isEmpty(request.getUuid())) {
 				throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
 			}
 			if (recordId <= 0) {
@@ -412,7 +413,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 	@Override
 	public void getPrivateAccess(GetPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
 		try {
-			if (request == null) {
+			if(request == null) {
 				throw new AdempiereException("Object Request Null");
 			}
 
@@ -427,7 +428,8 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			Properties context = ContextManager.getContext(request.getClientRequest().getSessionUuid(), request.getClientRequest().getLanguage(), request.getClientRequest().getOrganizationUuid(), request.getClientRequest().getWarehouseUuid());
 			MUser user = MUser.get(context);
 			MPrivateAccess privateAccess = getPrivateAccess(context, request.getTableName(), recordId, user.getAD_User_ID(), null);
-			if (privateAccess == null || privateAccess.getAD_Table_ID() == 0) {
+			if(privateAccess == null
+					|| privateAccess.getAD_Table_ID() == 0) {
 				MTable table = MTable.get(context, request.getTableName());
 				//	Set values
 				privateAccess = new MPrivateAccess(context, user.getAD_User_ID(), table.getAD_Table_ID(), recordId);

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -384,7 +384,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 					&& Util.isEmpty(request.getUuid())) {
 				throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
 			}
-			if (recordId <= 0) {
+			if(recordId <= 0) {
 				recordId = RecordUtil.getIdFromUuid(request.getTableName(), request.getUuid(), null);
 			}
 

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -369,69 +369,68 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 	
 	@Override
 	public void lockPrivateAccess(LockPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
-		try {
-			if(request == null) {
-				throw new AdempiereException("Object Request Null");
-			}
-			if(request.getId() <= 0
-					&& Util.isEmpty(request.getUuid())) {
-				throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
-			}
-			Properties context = ContextManager.getContext(request.getClientRequest().getSessionUuid(), request.getClientRequest().getLanguage(), request.getClientRequest().getOrganizationUuid(), request.getClientRequest().getWarehouseUuid());
-			int recordId = request.getId();
-			if(recordId <= 0) {
-				recordId = RecordUtil.getIdFromUuid(request.getTableName(), request.getUuid(), null);
-			}
-			MUser user = MUser.get(context);
-			PrivateAccess.Builder privateaccess = lockUnlockPrivateAccess(context, request.getTableName(), recordId, user.getAD_User_ID(), true, null);
-			responseObserver.onNext(privateaccess.build());
-			responseObserver.onCompleted();
-		} catch (Exception e) {
-			log.severe(e.getLocalizedMessage());
-			responseObserver.onError(Status.INTERNAL
-					.withDescription(e.getLocalizedMessage())
-					.augmentDescription(e.getLocalizedMessage())
-					.withCause(e)
-					.asRuntimeException());
-		}
+		setPrivateAccess(request, responseObserver, true);
 	}
 	
 	@Override
-	public void unlockPrivateAccess(UnlockPrivateAccessRequest request,
-			StreamObserver<PrivateAccess> responseObserver) {
+	public void unlockPrivateAccess(UnlockPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
+		setPrivateAccess(request, responseObserver, false);
+	}
+
+	public void setPrivateAccess(UnlockPrivateAccessRequest request,
+		StreamObserver<PrivateAccess> responseObserver,
+		boolean isPrivateAccess) {
 		try {
-			if(request == null) {
+			if (request == null) {
 				throw new AdempiereException("Object Request Null");
 			}
+
+			int recordId = request.getId();
+			if (recordId <= 0 && Util.isEmpty(request.getUuid())) {
+				throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
+			}
+			if (recordId <= 0) {
+				recordId = RecordUtil.getIdFromUuid(request.getTableName(), request.getUuid(), null);
+			}
+
 			Properties context = ContextManager.getContext(request.getClientRequest().getSessionUuid(), request.getClientRequest().getLanguage(), request.getClientRequest().getOrganizationUuid(), request.getClientRequest().getWarehouseUuid());
+
 			MUser user = MUser.get(context);
-			PrivateAccess.Builder privateaccess = lockUnlockPrivateAccess(context, request.getTableName(), request.getId(), user.getAD_User_ID(), false, null);
+			PrivateAccess.Builder privateaccess = lockUnlockPrivateAccess(context, request.getTableName(), recordId, user.getAD_User_ID(), isPrivateAccess, null);
 			responseObserver.onNext(privateaccess.build());
 			responseObserver.onCompleted();
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
 			responseObserver.onError(Status.INTERNAL
-					.withDescription(e.getLocalizedMessage())
-					.augmentDescription(e.getLocalizedMessage())
-					.withCause(e)
-					.asRuntimeException());
+				.withDescription(e.getLocalizedMessage())
+				.augmentDescription(e.getLocalizedMessage())
+				.withCause(e)
+				.asRuntimeException());
 		}
 	}
 	
 	@Override
 	public void getPrivateAccess(GetPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
 		try {
-			if(request == null) {
+			if (request == null) {
 				throw new AdempiereException("Object Request Null");
 			}
+
+			int recordId = request.getId();
+			if (recordId <= 0 && Util.isEmpty(request.getUuid())) {
+				throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
+			}
+			if (recordId <= 0) {
+				recordId = RecordUtil.getIdFromUuid(request.getTableName(), request.getUuid(), null);
+			}
+
 			Properties context = ContextManager.getContext(request.getClientRequest().getSessionUuid(), request.getClientRequest().getLanguage(), request.getClientRequest().getOrganizationUuid(), request.getClientRequest().getWarehouseUuid());
 			MUser user = MUser.get(context);
-			MPrivateAccess privateAccess = getPrivateAccess(context, request.getTableName(), request.getId(), user.getAD_User_ID(), null);
-			if(privateAccess == null
-					|| privateAccess.getAD_Table_ID() == 0) {
+			MPrivateAccess privateAccess = getPrivateAccess(context, request.getTableName(), recordId, user.getAD_User_ID(), null);
+			if (privateAccess == null || privateAccess.getAD_Table_ID() == 0) {
 				MTable table = MTable.get(context, request.getTableName());
 				//	Set values
-				privateAccess = new MPrivateAccess(context, user.getAD_User_ID(), table.getAD_Table_ID(), request.getId());
+				privateAccess = new MPrivateAccess(context, user.getAD_User_ID(), table.getAD_Table_ID(), recordId);
 				privateAccess.setIsActive(false);
 			}
 			PrivateAccess.Builder privateaccess = convertPrivateAccess(context, privateAccess);
@@ -440,10 +439,10 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
 			responseObserver.onError(Status.INTERNAL
-					.withDescription(e.getLocalizedMessage())
-					.augmentDescription(e.getLocalizedMessage())
-					.withCause(e)
-					.asRuntimeException());
+				.withDescription(e.getLocalizedMessage())
+				.augmentDescription(e.getLocalizedMessage())
+				.withCause(e)
+				.asRuntimeException());
 		}
 	}
 	

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -369,15 +369,15 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 	
 	@Override
 	public void lockPrivateAccess(LockPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
-		setPrivateAccess(request, responseObserver, true);
+		setPrivateAccess((GetPrivateAccessRequest) request, responseObserver, true);
 	}
 	
 	@Override
 	public void unlockPrivateAccess(UnlockPrivateAccessRequest request, StreamObserver<PrivateAccess> responseObserver) {
-		setPrivateAccess(request, responseObserver, false);
+		setPrivateAccess((GetPrivateAccessRequest) request, responseObserver, false);
 	}
 
-	public void setPrivateAccess(UnlockPrivateAccessRequest request,
+	public void setPrivateAccess(GetPrivateAccessRequest request,
 		StreamObserver<PrivateAccess> responseObserver,
 		boolean isPrivateAccess) {
 		try {

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -402,10 +402,10 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
 			responseObserver.onError(Status.INTERNAL
-				.withDescription(e.getLocalizedMessage())
-				.augmentDescription(e.getLocalizedMessage())
-				.withCause(e)
-				.asRuntimeException());
+					.withDescription(e.getLocalizedMessage())
+					.augmentDescription(e.getLocalizedMessage())
+					.withCause(e)
+					.asRuntimeException());
 		}
 	}
 	
@@ -439,10 +439,10 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
 			responseObserver.onError(Status.INTERNAL
-				.withDescription(e.getLocalizedMessage())
-				.augmentDescription(e.getLocalizedMessage())
-				.withCause(e)
-				.asRuntimeException());
+					.withDescription(e.getLocalizedMessage())
+					.augmentDescription(e.getLocalizedMessage())
+					.withCause(e)
+					.asRuntimeException());
 		}
 	}
 	


### PR DESCRIPTION

1. Open `Test` window
2. Create 1 record.
3. Lock record.
4. Refresh.
5. Select same locked record.

Currently, if you do not send the record ID when get private access or unlock private access, the default response is that you have access even if it is incorrect.

You should change private access requests to a generic request like `AccessRequest` since `GetPrivateAccessRequest`, `LockPrivateAccessRequest`, and `UnlockPrivateAccessRequest`, and include the `PrivateAccess` object have exactly the same attributes.

This way you could use a generic method that has the logic as `setPrivateAccess` where you send as parameter the boolean of `isPrivateAccess`, so `lockPrivateAccess` and `unlockPrivateAccess` would call only the `setPrivateAccess` method with a true or false as additional parameter.

```java
public void lockPrivateAccess(PrivateAccessRequest request, 
		StreamObserver<PrivateAccess> responseObserver) {
	setPrivateAccess(request, responseObserver, true);
}

public void unlockPrivateAccess(PrivateAccessRequest request,
		StreamObserver<PrivateAccess> responseObserver) {
	setPrivateAccess(request, responseObserver, false);
}

public void setPrivateAccess(PrivateAccessRequest request,
		StreamObserver<PrivateAccess> responseObserver,
		boolean isPrivateAccess) {
	// same logic to lockPrivateAccess and unlockPrivateAccess using 
	// boolean value isPrivateAccess param
}
```
