### PR TITLE
Adding improvement to search order by invoice number in the pos

### DIFF
--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -3425,7 +3425,16 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		}
 		//	Document No
 		if(!Util.isEmpty(request.getDocumentNo())) {
-			whereClause.append(" AND UPPER(DocumentNo) LIKE '%' || UPPER(?) || '%'");
+			whereClause.append(" AND (UPPER(DocumentNo) LIKE '%' || UPPER(?) || '%'");
+			whereClause.append(" OR EXISTS(");
+			whereClause.append("SELECT 1 ");
+			whereClause.append("FROM C_Invoice i ");
+			whereClause.append("JOIN C_InvoiceLine il ON i.C_Invoice_ID=il.C_Invoice_ID ");
+			whereClause.append("JOIN C_OrderLine ol ON il.C_OrderLine_ID=ol.C_OrderLine_ID ");
+			whereClause.append("WHERE ol.C_Order_ID=C_Order.C_Order_ID ");
+			whereClause.append("AND UPPER(i.DocumentNo) = UPPER(?)");
+			whereClause.append("))");
+			parameters.add(request.getDocumentNo());
 			parameters.add(request.getDocumentNo());
 		}
 		//	Business Partner


### PR DESCRIPTION
This change is in the order browser in the POS.
It allows searching with the "Document No" field, not only with the order number (as it was before) but also with the invoice number.

When a customer comes to a POS to return, he does so with an invoice, so this allows searching with that number.