### PR TITLE
Fixed error with columns not found

### DIFF
--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -2714,10 +2714,8 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		businessPartnerLocation.set_ValueOfColumn(VueStoreFrontUtil.COLUMNNAME_IsDefaultBilling, address.getIsDefaultBilling());
 		businessPartnerLocation.setIsShipTo(address.getIsDefaultShipping());
 		businessPartnerLocation.set_ValueOfColumn(VueStoreFrontUtil.COLUMNNAME_IsDefaultShipping, address.getIsDefaultShipping());
-		Optional.ofNullable(address.getContactName()).ifPresent(contactName -> businessPartnerLocation.set_ValueOfColumn("ContactName", contactName));
 		Optional.ofNullable(address.getContactName()).ifPresent(contact -> businessPartnerLocation.setContactPerson(contact));
 		Optional.ofNullable(address.getFirstName()).ifPresent(firstName -> businessPartnerLocation.setName(firstName));
-		Optional.ofNullable(address.getLastName()).ifPresent(lastName -> businessPartnerLocation.set_ValueOfColumn("Name2", lastName));
 		Optional.ofNullable(address.getEmail()).ifPresent(email -> businessPartnerLocation.setEMail(email));
 		Optional.ofNullable(address.getPhone()).ifPresent(phome -> businessPartnerLocation.setPhone(phome));
 		Optional.ofNullable(address.getDescription()).ifPresent(description -> businessPartnerLocation.set_ValueOfColumn("Description", description));


### PR DESCRIPTION
When trying to create a Business Partner from the POS (Adempiere-Vue), grpc throws the following error:
```
-----------------> MBPartnerLocation.get_Value: Column not found - Name2
-----------------> MBPartnerLocation.get_Value: Column not found - Name2
-----------------> MBPartnerLocation.get_Value: Column not found - ContacName
-----------------> MBPartnerLocation.get_Value: Column not found - ContacName
-----------------> MBPartnerLocation.get_Value: Column not found - Name2
-----------------> MBPartnerLocation.get_Value: Column not found - Name2
-----------------> MBPartnerLocation.get_Value: Column not found - ContacName
-----------------> MBPartnerLocation.get_Value: Column not found - ContacName
```
